### PR TITLE
Clean up button styles and add new variants

### DIFF
--- a/cypress/component/Button.cy.tsx
+++ b/cypress/component/Button.cy.tsx
@@ -3,19 +3,19 @@ import { composeStories } from '@storybook/testing-react'
 import * as stories from '../../src/stories/Button.stories'
 import terminalLog from '../support/component'
 
-const { Primary, Secondary, Loading, Small, Large, Disabled } = composeStories(stories)
+const { Primary, PrimaryIcon, Secondary, Loading, Small, Large, Disabled } = composeStories(stories)
 
 describe('Button.tsx', function () {
-	const label = 'Click Me!'
+	const label = <p>Click Me!</p>
 	beforeEach(() => {
 		cy.injectAxe()
 	})
 	it('should render component', () => {
-		cy.mount(<Primary label={label} />)
+		cy.mount(<Primary>{ label }</Primary>)
 		expect(cy.get('button')).to.exist
 	})
 	it('should have no accessibility violations', () => {
-		cy.mount(<Primary label={label} />)
+		cy.mount(<Primary>{ label }</Primary>)
 		cy.checkA11y(undefined, {
 			runOnly: {
 				type: 'tag',
@@ -24,43 +24,45 @@ describe('Button.tsx', function () {
 		}, terminalLog)
 	})
 	it('should render loading icon when loading prop is true', function () {
-		cy.mount(<Loading label={label} loading={true} />)
+		cy.mount(<Loading loading={true}>{ label }</Loading>)
 		cy.get('button').children().should('have.class', 'animate-spin')
 	})
 	//TODO: we are only checking if the class name is added but not if the css is actually applied
 	it('should have outline on focus', function() {
-		cy.mount(<Primary label={label} />)
+		cy.mount(<Primary>{ label }</Primary>)
 		cy.get('button').should('have.class', 'focus:outline-blue-500')
 		cy.get('button').should('have.class', 'focus:outline-dashed')
 	})
 	it('should render secondary variant when called', function() {
-		cy.mount(<Secondary label={label} primary={false} />)
-		cy.get('button').should('have.css', 'background-color')
+		cy.mount(<Secondary variant='secondary'>{ label }</Secondary>)
+		cy.get('button').should('have.class', 'bg-gray-300')
 	})
 	it('should be disabled when disable prop is true', function() {
-		cy.mount(<Disabled label={label} disabled={true} />)
+		cy.mount(<Disabled disabled={true}>{ label }</Disabled>)
 		cy.get('button').should('have.attr', 'disabled')
 	})
 	it('should have a type of button by default', function() {
-		cy.mount(<Primary label={label} />)
+		cy.mount(<Primary>{ label }</Primary>)
 		cy.get('button').should('have.attr', 'type', 'button')
 	})
 	it('should have a type of submit when type prop is submit', function() {
-		cy.mount(<Primary label={label} type="submit" />)
+		cy.mount(<Primary type="submit">{ label }</Primary>)
 		cy.get('button').should('have.attr', 'type', 'submit')
 	})
 	it('should have a type of reset when type prop is reset', function() {
-		cy.mount(<Primary label={label} type="reset" />)
+		cy.mount(<Primary type="reset">{ label }</Primary>)
 		cy.get('button').should('have.attr', 'type', 'reset')
 	})
+	it('should have medium weight font', function() {
+		cy.mount(<Primary>{ label }</Primary>)
+		cy.get('button').should('have.class', 'font-medium')
+	})
 	it('should have increased size if size prop is set to large', function() {
-		cy.mount(<Large label={label} size="large" />)
-		cy.get('button').should('have.css', 'padding', '32px 40px')
-		cy.get('button').should('have.class', 'h-12 w-auto py-8 px-10')
+		cy.mount(<Large size="large">{ label }</Large>)
+		cy.get('button').should('have.class', 'text-lg')
 	})
 	it('should have decreased size if size prop is set to small', function() {
-		cy.mount(<Small label={label} size="small" />)
-		cy.get('button').should('have.css', 'padding', '16px 8px')
-		cy.get('button').should('have.class', 'h-4 w-auto py-4 px-2')
+		cy.mount(<Small size="small">{ label }</Small>)
+		cy.get('button').should('have.class', 'text-sm')
 	})
 })

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -3,44 +3,50 @@ import * as React from 'react'
 import Loader from '../../util/Loader'
 
 export const Button = ({
-	primary,
+	variant,
 	loading,
 	size,
-	label,
+	children,
 	disabled,
 	type,
 	...props
 }: ButtonProps): JSX.Element => {
-	const baseStyles =
-		'rounded-md flex items-center focus:outline-dashed focus:outline-blue-500'
-	const variant: string = primary
+	const variantStyles: string = variant
 		? 'bg-blue-700 text-white hover:bg-blue-500 '
 		: 'bg-blue-300 text-black hover:bg-blue-100 '
-	let buttonSize = ''
-	if (size === 'small') {
-		buttonSize = 'h-4 w-auto py-4 px-2'
-	} else if (size === 'large') {
-		buttonSize = 'h-12 w-auto py-8 px-10'
-	} else if (size === 'base') {
-		buttonSize = 'h-10 w-auto py-2 px-5'
-	}
 
 	return (
 		<button
 			type={type}
 			disabled={disabled}
 			className={[
+				'flex flex-row items-center justify-center gap-2',
+				'rounded',
+				'focus:outline-dashed focus:outline-blue-500',
+				'px-4 py-2',
+				'font-medium',
+
+				size == 'small' && 'text-sm',
+				size == 'large' && 'text-lg',
+
 				disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer',
-				baseStyles,
-				buttonSize,
-				variant,
+
+				variant == 'primary' &&
+					'shadow bg-blue-700 text-white hover:bg-blue-600',
+				variant == 'secondary' &&
+					'shadow bg-gray-300 text-gray-700 hover:bg-gray-200',
+				variant == 'transparent' && 'bg-transparent text-black',
 			].join(' ')}
 			{...props}
 		>
 			{loading ? (
-				<Loader textColor={`${primary ? 'blue-700' : 'blue-200'}`} />
+				<Loader
+					textColor={`${
+						variant == 'primary' ? 'blue-700' : 'blue-200'
+					}`}
+				/>
 			) : null}
-			{label}
+			{children}
 		</button>
 	)
 }
@@ -49,7 +55,7 @@ type ButtonProps = {
 	/**
 	 * A boolean that determines whether the button is the principal call/action on the page
 	 */
-	primary?: boolean
+	variant?: 'primary' | 'secondary' | 'transparent'
 	/**
 	 * A boolean that determines whether the button is representing a loading state
 	 */
@@ -63,9 +69,9 @@ type ButtonProps = {
 	 */
 	type: 'button' | 'submit' | 'reset'
 	/**
-	 * A descriptive label to display the text content on the button
+	 * The JSX contnet to be displayed within the button
 	 */
-	label: string
+	children: React.ReactNode
 	/**
 	 * A boolean that determines whether the button representing a disabled state
 	 */
@@ -80,7 +86,7 @@ Button.propTypes = {
 	/**
 	 * Is this the principal call to action on the page?
 	 */
-	primary: PropTypes.bool,
+	variant: PropTypes.oneOf(['primary', 'secondary', 'transparent']),
 	/**
 	 * Is the button representing a loading state?
 	 */
@@ -92,7 +98,7 @@ Button.propTypes = {
 	/**
 	 * Button contents
 	 */
-	label: PropTypes.string.isRequired,
+	children: PropTypes.element,
 	/**
 	 * Optional click handler
 	 */
@@ -108,11 +114,11 @@ Button.propTypes = {
 }
 
 Button.defaultProps = {
-	primary: true,
+	variant: 'primary',
 	loading: false,
 	size: 'base',
 	onClick: undefined,
-	label: 'Click here!',
+	children: <p>Click Here</p>,
 	disabled: false,
 	type: 'button',
 }

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -1,25 +1,20 @@
 import { Button } from '../components/Button'
 import * as React from 'react'
 import { ComponentMeta, ComponentStory } from '@storybook/react'
+import { HiLightningBolt } from 'react-icons/hi'
 
 export default {
 	title: 'Atoms/Button',
 	component: Button,
 	argTypes: {
-		label: {
-			control: 'text',
-			description:
-				'The text to be rendered inside of the button component.',
-		},
 		size: {
 			control: 'select',
 			options: ['small', 'base', 'large'],
 			description: 'The size of the button.',
 		},
-		primary: {
-			control: 'boolean',
-			description:
-				'Decides whether the button is the a main call to action on the page or just a supplementary element.',
+		variant: {
+			control: 'select',
+			description: 'Decides the which variant should be rendered.',
 		},
 		loading: {
 			control: 'boolean',
@@ -45,15 +40,34 @@ const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />
 
 export const Primary = Template.bind({})
 Primary.args = {
-	primary: true,
+	variant: 'primary',
 	loading: false,
 	size: 'base',
 	disabled: false,
 }
 
+export const PrimaryIcon = Template.bind({})
+PrimaryIcon.args = {
+	variant: 'primary',
+	loading: false,
+	size: 'base',
+	disabled: false,
+	children: (
+		<>
+			<HiLightningBolt />
+			<p>Hello World</p>
+		</>
+	),
+}
+
 export const Secondary = Template.bind({})
 Secondary.args = {
-	primary: false,
+	variant: 'secondary',
+}
+
+export const Transparent = Template.bind({})
+Transparent.args = {
+	variant: 'transparent',
 }
 
 export const Large = Template.bind({})
@@ -71,14 +85,14 @@ Small.args = {
 }
 export const Loading = Template.bind({})
 Loading.args = {
-	primary: true,
+	variant: 'primary',
 	size: 'base',
 	loading: true,
 	disabled: false,
 }
 export const Disabled = Template.bind({})
 Disabled.args = {
-	primary: true,
+	variant: 'primary',
 	size: 'base',
 	loading: false,
 	disabled: true,


### PR DESCRIPTION
+ Added variant enum ['primary', 'secondary', 'transparent']
+ Adjusted styles and cleaned up code.
+ Added `children` prop to allow for more complex labels
+ Updated test cases

- Removed `primary` prop
- Removed  `label` prop